### PR TITLE
updated repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jquense/inline-module-loader.git"
+    "url": "git+https://github.com/4Catalyzer/css-literal-loader.git"
   },
   "files": [
     "lib"


### PR DESCRIPTION
the previous one seems to be outdated
https://www.npmjs.com/package/css-literal-loader