### PR TITLE
allow whitespace after tag

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -27,7 +27,7 @@ function collectStyles(src, filename, opts) {
   if (
     !src.match(
       new RegExp(
-        `(${opts.tagName || 'css'}|styled\\(.+\\))\`([\\s\\S]*?)\``,
+        `(${opts.tagName || 'css'}|styled\\(.+\\))\\s*\`([\\s\\S]*?)\``,
         'gmi',
       ),
     )


### PR DESCRIPTION
Allow whitespace after tag like below
```javascript
const style = css `
  color: black;
`;
```

---
I'm a TypeScript user.
README says css-literal-loader must be called before ts-loader, but it's difficult because css-literal-loader can't parse typescript code which contains complex generics.

If this PR is merged, we can put css-literal-loader after ts-loader on the condition that "css" must be declared as global.

This works

```typescript
declare function css(strings: TemplateStringsArray, ...interpolations: any[]): any;

const style = css`
  ...
`;
```

This still does not work

```typescript
import { css } from "css-literal-loader/styled";
const style = css`
  ...
`;
```